### PR TITLE
Fix - Ao capturar uma data permitir o padrão ISO_DATE_TIME

### DIFF
--- a/src/main/java/umari/datafilter/predicate/GreaterThanOrEqualsToPredicate.java
+++ b/src/main/java/umari/datafilter/predicate/GreaterThanOrEqualsToPredicate.java
@@ -48,8 +48,10 @@ public class GreaterThanOrEqualsToPredicate extends AbstractPredicate {
 	}
 
 	private LocalDate getLocalDateValue(Object value) {
-		if (((String) this.getValue()).equals("@now")) return LocalDate.now();
-		return LocalDate.parse((String) this.getValue(), DateTimeFormatter.ISO_DATE);
+		String stringValue = (String) this.getValue();
+		if ((stringValue).equals("@now")) return LocalDate.now();
+		DateTimeFormatter formatter = stringValue.contains("T") ?  DateTimeFormatter.ISO_DATE_TIME : DateTimeFormatter.ISO_DATE;
+		return LocalDate.parse((String) this.getValue(), formatter);
 	}
 
 	private LocalDateTime getLocalDateTimeValue(Object value) {

--- a/src/main/java/umari/datafilter/predicate/GreaterThanPredicate.java
+++ b/src/main/java/umari/datafilter/predicate/GreaterThanPredicate.java
@@ -41,8 +41,10 @@ public class GreaterThanPredicate extends AbstractPredicate {
 	}
 
 	private LocalDate getLocalDateValue(Object value) {
-		if (((String) this.getValue()).equals("@now")) return LocalDate.now();
-		return LocalDate.parse((String) this.getValue(), DateTimeFormatter.ISO_DATE);
+		String stringValue = (String) this.getValue();
+		if ((stringValue).equals("@now")) return LocalDate.now();
+		DateTimeFormatter formatter = stringValue.contains("T") ?  DateTimeFormatter.ISO_DATE_TIME : DateTimeFormatter.ISO_DATE;
+		return LocalDate.parse((String) this.getValue(), formatter);
 	}
 
 	private LocalDateTime getLocalDateTimeValue(Object value) {

--- a/src/main/java/umari/datafilter/predicate/LessThanOrEqualsToPredicate.java
+++ b/src/main/java/umari/datafilter/predicate/LessThanOrEqualsToPredicate.java
@@ -45,8 +45,10 @@ public class LessThanOrEqualsToPredicate extends AbstractPredicate {
 	}
 
 	private LocalDate getLocalDateValue(Object value) {
-		if (((String) this.getValue()).equals("@now")) return LocalDate.now();
-		return LocalDate.parse((String) this.getValue(), DateTimeFormatter.ISO_DATE);
+		String stringValue = (String) this.getValue();
+		if ((stringValue).equals("@now")) return LocalDate.now();
+		DateTimeFormatter formatter = stringValue.contains("T") ?  DateTimeFormatter.ISO_DATE_TIME : DateTimeFormatter.ISO_DATE;
+		return LocalDate.parse((String) this.getValue(), formatter);
 	}
 
 	private LocalDateTime getLocalDateTimeValue(Object value) {

--- a/src/main/java/umari/datafilter/predicate/LessThanPredicate.java
+++ b/src/main/java/umari/datafilter/predicate/LessThanPredicate.java
@@ -47,8 +47,10 @@ public class LessThanPredicate extends AbstractPredicate {
 	}
 
 	private LocalDate getLocalDateValue(Object value) {
-		if (((String) this.getValue()).equals("@now")) return LocalDate.now();
-		return LocalDate.parse((String) this.getValue(), DateTimeFormatter.ISO_DATE);
+		String stringValue = (String) this.getValue();
+		if ((stringValue).equals("@now")) return LocalDate.now();
+		DateTimeFormatter formatter = stringValue.contains("T") ?  DateTimeFormatter.ISO_DATE_TIME : DateTimeFormatter.ISO_DATE;
+		return LocalDate.parse((String) this.getValue(), formatter);
 	}
 
 	private LocalDateTime getLocalDateTimeValue(Object value) {


### PR DESCRIPTION
# Finalidade
Permitir que os predicates de data recebem data no padrão ISO_DATE_TIME(ex.: 1900-01-01T03:13:56.000Z).